### PR TITLE
fix: Correct indentation for code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,12 @@ See [String Normalizer Documentation](/src/utils/stringNormalizer/README.md) for
 
 ### Installation
 1. Clone the repo:
-   ```sh
+```sh
 git clone https://github.com/caomicc/polisheddex.git
 cd polisheddex
 ```
 2. Install dependencies:
-   ```sh
+```sh
 npm install
 # or
 yarn install
@@ -67,7 +67,7 @@ yarn install
    - If you need to regenerate data, use the provided scripts (e.g. `extract_pokemon_data.ts`).
 
 4. Run the development server:
-   ```sh
+```sh
 npm run dev
 # or
 yarn dev


### PR DESCRIPTION
Updates the indentation for the code blocks, resolving github markdown rendering issues

BEFORE:
<img width="941" height="967" alt="image" src="https://github.com/user-attachments/assets/a2f60fae-f60b-49a9-ab65-bd6569f3c8f7" />

AFTER
<img width="1340" height="1100" alt="image" src="https://github.com/user-attachments/assets/2c2756ad-7d2d-468c-a8dd-07ad1e857094" />
