### PR TITLE
Fix/sprite-name-regex

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -18,7 +18,7 @@ const buttonVariants = cva(
         ghost: 'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50',
         link: 'text-primary underline-offset-4 hover:underline',
         save: 'bg-grass text-white shadow-xs hover:bg-grass/90 focus-visible:ring-grass/20 dark:focus-visible:ring-grass/40 dark:bg-grass/60 cursor-pointer',
-        load: 'bg-cyan-200 text-cyan-900 hover:bg-cyan-400 shadow-xs focus-visible:ring-dark/20 dark:focus-visible:ring-dark/40 dark:bg-dark/60',
+        load: 'bg-cyan-200 text-cyan-900 hover:bg-cyan-400 shadow-xs hover:text-cyan-900 focus-visible:ring-dark/20 dark:focus-visible:ring-dark/40 dark:text-cyan-100 dark:bg-cyan-900',
         bugs: 'bg-pink-200 text-pink-950 shadow-xs hover:bg-pink-300 hover:text-pink-950 dark:text-pink-100 focus-visible:ring-dark/20 dark:focus-visible:ring-dark/40 dark:bg-pink-950',
       },
       size: {

--- a/src/hooks/useSpriteData.ts
+++ b/src/hooks/useSpriteData.ts
@@ -50,7 +50,8 @@ export function useSpriteData(
 
     try {
       // Construct the full sprite name including form if provided
-      const fullSpriteName = form !== 'plain' ? `${spriteName}_${form}` : spriteName;
+      const fullSpriteName =
+        form !== undefined && form !== 'plain' ? `${spriteName}_${form}` : spriteName;
       console.log(
         `DEBUG: Fetching sprite for ${fullSpriteName} with variant=${variant} and type=${type}`,
       );

--- a/src/utils/spriteUtils.ts
+++ b/src/utils/spriteUtils.ts
@@ -50,7 +50,12 @@ export function getSprite(
   variant: SpriteVariant = 'normal',
   type: SpriteType = 'static',
 ): SpriteInfo | null {
-  const normalizedName = pokemonName.toLowerCase().replace(/-/g, '_');
+  const normalizedName = pokemonName
+    .toLowerCase()
+    .replace(/-/g, '_')
+    .replace(/\(/g, '_')
+    .replace(/\)/g, '')
+    .replace(/\s/g, '');
 
   // Handle both unified and legacy manifests
   const pokemonData =


### PR DESCRIPTION
Missing sprites in the team builder due to name normalization regex:
<img width="523" height="440" alt="image" src="https://github.com/user-attachments/assets/629083df-4ab8-445a-8bc3-59dd20ac9b1d" />

After regex fix:
<img width="518" height="448" alt="image" src="https://github.com/user-attachments/assets/0f540143-21f5-45c2-aa37-9dcbfc6d4a3a" />



Dark mode load variant button before:
<img width="830" height="296" alt="image" src="https://github.com/user-attachments/assets/c0744de4-0cb2-451b-960c-1d85c2a47570" />

After:
<img width="938" height="294" alt="image" src="https://github.com/user-attachments/assets/3d61b932-7460-4ba9-b186-c8aa346baff2" />

