### PR TITLE
fixed type normalization for mons with 1 type only

### DIFF
--- a/src/lib/pokemon-data.ts
+++ b/src/lib/pokemon-data.ts
@@ -119,6 +119,9 @@ export async function loadPokemonData(): Promise<PokemonBasic[]> {
 
         if (Array.isArray(pokemon.types)) {
           typeArray = pokemon.types.map((t: string) => normalizeTypeName(t)).slice(0, 2);
+        } else {
+          // Make sure pokemon with a single type are stored correctly
+          typeArray = [normalizeTypeName(pokemon.types), null];
         }
 
         // Ensure we always have exactly 2 elements
@@ -215,6 +218,8 @@ export async function loadPokemonData(): Promise<PokemonBasic[]> {
 
         if (Array.isArray(typesData)) {
           typeArray = typesData.map((t: string) => normalizeTypeName(t)).slice(0, 2);
+        } else {
+          typeArray = [normalizeTypeName(typesData), null];
         }
 
         // Ensure we always have exactly 2 elements


### PR DESCRIPTION
When searching for a type, pokemon with only a single type were being formatted as type: [null, null], not showing up in the search as expected.

(If searching "grass" you would not see tangela for example)

